### PR TITLE
Installation and sync enhanced

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,3 @@
+# this is an example environmental file, copy it to .env and fill with your data
+MAILCHIMP_CLIENT_ID=
+MAILCHIMP_CLIENT_SECRET=

--- a/assets/auth.css
+++ b/assets/auth.css
@@ -19,3 +19,7 @@
   width: 37px;
   position: relative;
 }
+
+.btn {
+  white-space: normal;
+}

--- a/assets/auth.css
+++ b/assets/auth.css
@@ -1,0 +1,21 @@
+.media {
+  margin: 0 40px;
+}
+.check i.icon {
+  color: rgba(75, 222, 122, 0.52);
+  font-size: 2pc;
+  position: relative;
+  top: -11px;
+  left: 3px;
+}
+.check.valid {
+  border-color: rgba(75, 222, 122, 0.52);
+}
+.check {
+  border-radius: 100px;
+  border: 2px solid transparent;
+  padding: 0 5px;
+  height: 37px;
+  width: 37px;
+  position: relative;
+}

--- a/bin/start
+++ b/bin/start
@@ -1,7 +1,4 @@
 #!/usr/bin/env node
 
 require("babel-register");
-var Server = require('../server').Server;
-var PORT = process.env.PORT || 8082;
-console.warn("Starting on PORT " + PORT);
-Server().listen(PORT);
+require('../main.js');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+    node-cli:
+        image: node
+        env_file: .env
+        command: bash
+        working_dir: /app
+        ports:
+            - "8082:8082"
+        volumes:
+            - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,12 @@ services:
             - "8082:8082"
         volumes:
             - .:/app
+    watch:
+        image: node
+        env_file: .env
+        command: npm run watch
+        working_dir: /app
+        ports:
+            - "8082:8082"
+        volumes:
+            - .:/app

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-var Server = require('./server').Server;
-var PORT = process.env.PORT || 8082;
-console.warn("Starting on PORT " + PORT);
+const Server = require("./server").Server;
+const PORT = process.env.PORT || 8082;
+console.warn(`Starting on PORT ${PORT}`);
 Server().listen(PORT);

--- a/main.js
+++ b/main.js
@@ -1,0 +1,4 @@
+var Server = require('./server').Server;
+var PORT = process.env.PORT || 8082;
+console.warn("Starting on PORT " + PORT);
+Server().listen(PORT);

--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,9 @@
     {
       "name": "list_id",
       "title": "Mailchimp List ID",
-      "description": "Create a list and find it's ID here: http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id",
-      "type": "string"
+      "description": "Mailchimp List ID selected by user",
+      "type": "string",
+      "format": "hidden"
     },
     {
       "name": "api_key",

--- a/manifest.json
+++ b/manifest.json
@@ -15,21 +15,18 @@
       "format": "segment"
     },
     {
-      "name": "mailchimp_list",
-      "title": "Mailchimp List object",
-      "description": "Mailchimp List object selected by user",
-      "type": "object",
-      "format": "hidden",
-      "properties": {
-        "id": {
-          "title": "Mailchimp List ID",
-          "type": "string"
-        },
-        "name": {
-          "title": "Mailchimp List name",
-          "type": "string"
-        }
-      }
+      "name": "mailchimp_list_id",
+      "title": "Mailchimp List ID",
+      "description": "Mailchimp List ID selected by user",
+      "type": "string",
+      "format": "hidden"
+    },
+    {
+      "name": "mailchimp_list_name",
+      "title": "Mailchimp List Name",
+      "description": "Mailchimp List Name selected by user",
+      "type": "string",
+      "format": "hidden"
     },
     {
       "name": "api_key",

--- a/manifest.json
+++ b/manifest.json
@@ -15,16 +15,33 @@
       "format": "segment"
     },
     {
-      "name": "list_id",
-      "title": "Mailchimp List ID",
-      "description": "Mailchimp List ID selected by user",
-      "type": "string",
-      "format": "hidden"
+      "name": "mailchimp_list",
+      "title": "Mailchimp List object",
+      "description": "Mailchimp List object selected by user",
+      "type": "object",
+      "format": "hidden",
+      "properties": {
+        "id": {
+          "title": "Mailchimp List ID",
+          "type": "string"
+        },
+        "name": {
+          "title": "Mailchimp List name",
+          "type": "string"
+        }
+      }
     },
     {
       "name": "api_key",
       "title": "API Key",
       "description": "Token or API Key",
+      "type": "string",
+      "format": "hidden"
+    },
+    {
+      "name": "api_endpoint",
+      "title": "API Endpoint",
+      "description": "Mailchimp API endpoint",
       "type": "string",
       "format": "hidden"
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hull Mailchimp integration",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint server",
     "start": "./bin/start",
     "test": "NODE_ENV=test mocha -R spec ./tests/index",
     "watch": "babel-watch -L main.js"
@@ -34,6 +34,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "babel-register": "^6.4.3",
+    "batch-stream": "^0.1.3",
     "bluebird": "^3.3.5",
     "body-parser": "^1.15.1",
     "csv-stream": "^0.1.3",
@@ -49,6 +50,7 @@
     "mailchimp": "^1.1.6",
     "mailchimp-api-v3": "^1.4.0",
     "object-mapper": "^3.0.1",
+    "promise-streams": "^1.0.1",
     "request": "^2.72.0",
     "request-promise": "^3.0.0",
     "simple-oauth2": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint": "^1.1.2",
     "lodash": "^4.12.0",
     "mailchimp": "^1.1.6",
-    "mailchimp-api-v3": "^1.0.0",
+    "mailchimp-api-v3": "^1.4.0",
     "object-mapper": "^3.0.1",
     "request": "^2.72.0",
     "request-promise": "^3.0.0",
@@ -61,6 +61,7 @@
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.0",
     "mocha": "^2.5.2",
+    "sinon": "^1.17.4",
     "supertest": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint src",
     "start": "./bin/start",
-    "test": "NODE_ENV=test mocha -R spec ./tests/index"
+    "test": "NODE_ENV=test mocha -R spec ./tests/index",
+    "watch": "./node_modules/.bin/babel-watch -L main.js"
   },
   "engines": {
     "node": "5.x",
@@ -55,10 +56,11 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
+    "babel-watch": "^2.0.2",
     "eslint": "^2.9.0",
     "eslint-config-airbnb-base": "^3.0.1",
-    "supertest": "^1.2.0",
+    "eslint-plugin-import": "^1.8.0",
     "mocha": "^2.5.2",
-    "eslint-plugin-import": "^1.8.0"
+    "supertest": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Hull Mailchimp integration",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint src",
+    "lint": "eslint .",
     "start": "./bin/start",
     "test": "NODE_ENV=test mocha -R spec ./tests/index",
-    "watch": "./node_modules/.bin/babel-watch -L main.js"
+    "watch": "babel-watch -L main.js"
   },
   "engines": {
     "node": "5.x",

--- a/server/index.js
+++ b/server/index.js
@@ -51,7 +51,7 @@ export function Server() {
     const agent = new MailchimpAgent(ship, client, req, MailchimpClient);
 
     if (!agent.isConfigured()) {
-      return res.status(500).send('Ship is not configured properly');
+      return res.status(403).send('Ship is not configured properly');
     }
 
     if (ship && audience) {
@@ -69,7 +69,7 @@ export function Server() {
 
       client.utils.log('request.batch');
       if (!agent.isConfigured()) {
-        return res.status(500).send('Ship is not configured properly');
+        return res.status(403).send('Ship is not configured properly');
       }
 
       agent.getAudiencesBySegmentId().then(audiences => {

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ export function Server() {
     clientSecret: process.env.MAILCHIMP_CLIENT_SECRET,
     callbackUrl: "/callback",
     homeUrl: "/",
+    selectUrl: "/select",
     site: "https://login.mailchimp.com",
     tokenPath: "/oauth2/token",
     authorizationPath: "/oauth2/authorize"

--- a/server/index.js
+++ b/server/index.js
@@ -54,13 +54,9 @@ export function Server() {
     client.utils.log("request.batch.start");
     return agent.handleExtract(req.body, users => {
       client.utils.log("request.batch.parseChunk", users.length);
-      const usersToUnsubscribe = _.reject(users, agent.shouldSyncUser.bind(agent));
       const filteredUsers = users.filter(agent.shouldSyncUser.bind(agent));
 
-      return agent.addUsersToAudiences(filteredUsers)
-        .then(() => {
-          return agent.removeUsersFromAudiences(usersToUnsubscribe);
-        });
+      return agent.addUsersToAudiences(filteredUsers);
     }).then(() => {
       client.utils.log("request.batch.end");
       res.end("ok");

--- a/server/index.js
+++ b/server/index.js
@@ -63,7 +63,9 @@ export function Server() {
       agent.fetchAudiencesBySegmentId().then(audiences => {
         agent.handleExtract(req.body, users => {
           const usersByAudience = {};
-          users.map(user => {
+          var filteredUsers = users.filter(agent.shouldSyncUser.bind(agent));
+
+          filteredUsers.map(user => {
             return user.segment_ids.map(segmentId => {
               const { audience } = audiences[segmentId] || {};
               if (audience) {

--- a/server/index.js
+++ b/server/index.js
@@ -47,8 +47,13 @@ export function Server() {
   app.post("/sync", bodyParser.json(), fetchShip, (req, res) => {
     const { ship, client } = req.hull || {};
     const { audience } = req.query;
-    client.utils.log("Received Batch", audience);
+    client.utils.log("request.sync", audience);
     const agent = new MailchimpAgent(ship, client, req, MailchimpClient);
+
+    if (!agent.isConfigured()) {
+      return res.status(500).send('Ship is not configured properly');
+    }
+
     if (ship && audience) {
       agent.handleExtract(req.body, users => {
         agent.addUsersToAudience(audience, users);
@@ -61,6 +66,12 @@ export function Server() {
     const { ship, client } = req.hull || {};
     const agent = new MailchimpAgent(ship, client, req, MailchimpClient);
     if (ship) {
+
+      client.utils.log('request.batch');
+      if (!agent.isConfigured()) {
+        return res.status(500).send('Ship is not configured properly');
+      }
+
       agent.getAudiencesBySegmentId().then(audiences => {
         agent.handleExtract(req.body, users => {
           const usersByAudience = {};

--- a/server/index.js
+++ b/server/index.js
@@ -63,7 +63,7 @@ export function Server() {
       agent.fetchAudiencesBySegmentId().then(audiences => {
         agent.handleExtract(req.body, users => {
           const usersByAudience = {};
-          var filteredUsers = users.filter(agent.shouldSyncUser.bind(agent));
+          const filteredUsers = users.filter(agent.shouldSyncUser.bind(agent));
 
           filteredUsers.map(user => {
             return user.segment_ids.map(segmentId => {

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,7 @@ export function Server() {
     callbackUrl: "/callback",
     homeUrl: "/",
     selectUrl: "/select",
+    syncUrl: "/sync",
     site: "https://login.mailchimp.com",
     tokenPath: "/oauth2/token",
     authorizationPath: "/oauth2/authorize"

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -69,7 +69,7 @@ export default class MailchimpList extends SyncAgent {
     return [
       "api_key",
       "domain",
-      "mailchimp_list"
+      "mailchimp_list_id"
     ];
   }
 

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -184,8 +184,12 @@ export default class MailchimpList extends SyncAgent {
     }, (err) => this.hull.utils.log("Error in addUsersToAudience", err));
   }
 
-  // Ensure users are subscribed to the list
-  // before trying to add them to the audience
+  /**
+   * Ensure users are subscribed to the list
+   * before trying to add them to the audience
+   * @param  {Array} users
+   * @return {[type]}       [description]
+   */
   ensureUsersSubscribed(users = []) {
     const subscribedUsers = users.filter(
       user => !_.isEmpty(user["traits_mailchimp/unique_email_id"])

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -120,12 +120,12 @@ export default class MailchimpList extends SyncAgent {
    */
   fetchUsers() {
     const listId = this.getClient().list_id;
-    const MailchimpClient = this.getClient().client;
-    return MailchimpClient.batch({
-      method : 'get',
-      path : `/lists/${listId}/members`,
-      query : {
-        count  : 10000000000,
+    const rawClient = this.getClient().client;
+    return rawClient.batch({
+      method: "get",
+      path: `/lists/${listId}/members`,
+      query: {
+        count: 10000000000,
       }
     });
   }
@@ -136,22 +136,21 @@ export default class MailchimpList extends SyncAgent {
    */
   removeAllUsers() {
     const listId = this.getClient().list_id;
-    const MailchimpClient = this.getClient().client;
+    const rawClient = this.getClient().client;
     return this.fetchUsers().then(res => {
       const calls = res.members.map(member => {
         const hash = getEmailHash(member.email_address);
         return {
-          method : 'delete',
-          path : `/lists/${listId}/members/${hash}`
-        }
+          method: "delete",
+          path: `/lists/${listId}/members/${hash}`
+        };
       });
-      return MailchimpClient.batch(calls, {
-        wait : true,
-        interval : 2000,
-        unpack : false,
+      return rawClient.batch(calls, {
+        wait: true,
+        interval: 2000,
+        unpack: false,
       });
-
-    })
+    });
   }
 
   /**
@@ -160,28 +159,27 @@ export default class MailchimpList extends SyncAgent {
    */
   removeAllAudiences() {
     const listId = this.getClient().list_id;
-    const MailchimpClient = this.getClient().client;
-    return MailchimpClient.batch({
-        method : 'get',
-        path : `/lists/${listId}/segments`,
-        query : {
-          count: 10000000000,
-          type: 'static'
-        }
+    const rawClient = this.getClient().client;
+    return rawClient.batch({
+      method: "get",
+      path: `/lists/${listId}/segments`,
+      query: {
+        count: 10000000000,
+        type: "static"
+      }
     }).then(res => {
       const calls = res.segments.map(segment => {
         return {
-          method : 'delete',
-          path : `/lists/${listId}/segments/${segment.id}`
-        }
+          method: "delete",
+          path: `/lists/${listId}/segments/${segment.id}`
+        };
       });
 
-      return MailchimpClient.batch(calls, {
-        wait : true,
-        interval : 2000,
-        unpack : false,
+      return rawClient.batch(calls, {
+        wait: true,
+        interval: 2000,
+        unpack: false,
       });
-
     });
   }
 

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -69,7 +69,7 @@ export default class MailchimpList extends SyncAgent {
     return [
       "api_key",
       "domain",
-      "list_id"
+      "mailchimp_list"
     ];
   }
 

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -159,9 +159,10 @@ export default class MailchimpList extends SyncAgent {
   }
 
   /**
-   * [addUsersToAudience description]
-   * @param {[type]} audienceId [description]
-   * @param {[type]} users      =             [] [description]
+   * Ensures that all provided users are subscribed to Mailchimp,
+   * then adds them to selected audience and updates Hull traits.
+   * @param {Int} audienceId
+   * @return {Promise}
    */
   addUsersToAudience(audienceId, users = []) {
     const usersToAdd = users.filter(u => !_.isEmpty(u.email));
@@ -188,7 +189,7 @@ export default class MailchimpList extends SyncAgent {
    * Ensure users are subscribed to the list
    * before trying to add them to the audience
    * @param  {Array} users
-   * @return {[type]}       [description]
+   * @return {Promise}
    */
   ensureUsersSubscribed(users = []) {
     const subscribedUsers = users.filter(

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -31,7 +31,7 @@ export default class MailchimpList extends SyncAgent {
     return ({ message }, { hull, ship, req }) => {
       const handler = new MailchimpList(ship, hull, req, MailchimpClientClass);
       if (!handler.isConfigured()) {
-        const error = new Error("Missing credentials");
+        const error = new Error("Ship not configured properly. Missing credentials");
         error.status = 403;
         return Promise.reject(error);
       }

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -15,8 +15,6 @@ export default class MailchimpClient {
   // params can be either an operation or an array of operations
   // Operation : { path, body, method }
   // If array of operations and length > 1 we automatically use Mailchimp's batch api
-
-
   request(params) {
     const { client, list_id } = this;
     return new Promise((resolve, reject) => {

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -38,7 +38,10 @@ export default class MailchimpClient {
           };
         });
         if (ops.length > 0) {
-          client.batch(ops, callback);
+          client.batch(ops, callback, {
+            interval: 2000,
+            verbose: false,
+          });
         } else {
           resolve([]);
         }

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -5,10 +5,9 @@ import Mailchimp from "mailchimp-api-v3";
 export default class MailchimpClient {
 
   constructor({ api_key, domain, list_id }) {
-
     // the mailchimp-api-v3 library splits the api_key using dash and uses
     // second part as a api datacenter
-    this.client = new Mailchimp(api_key + '-' + domain);
+    this.client = new Mailchimp(`${api_key}-${domain}`);
     this.list_id = list_id;
   }
 

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -5,8 +5,10 @@ import Mailchimp from "mailchimp-api-v3";
 export default class MailchimpClient {
 
   constructor({ api_key, domain, list_id }) {
-    this.client = new Mailchimp(api_key);
-    this.client.__base_url = `https://${domain}.api.mailchimp.com/3.0`;
+
+    // the mailchimp-api-v3 library splits the api_key using dash and uses
+    // second part as a api datacenter
+    this.client = new Mailchimp(api_key + '-' + domain);
     this.list_id = list_id;
   }
 

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -4,11 +4,14 @@ import Mailchimp from "mailchimp-api-v3";
 
 export default class MailchimpClient {
 
-  constructor({ api_key, domain, list_id }) {
+  constructor({ api_key, domain, mailchimp_list = {} }) {
     // the mailchimp-api-v3 library splits the api_key using dash and uses
     // second part as a api datacenter
     this.client = new Mailchimp(`${api_key}-${domain}`);
-    this.list_id = list_id;
+    if (!mailchimp_list.id) {
+      throw new Error("No mailchimp list set");
+    }
+    this.list_id = mailchimp_list.id;
   }
 
   // Mailchimp API request

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -4,14 +4,11 @@ import Mailchimp from "mailchimp-api-v3";
 
 export default class MailchimpClient {
 
-  constructor({ api_key, domain, mailchimp_list = {} }) {
+  constructor({ api_key, domain, mailchimp_list_id = {} }) {
     // the mailchimp-api-v3 library splits the api_key using dash and uses
     // second part as a api datacenter
     this.client = new Mailchimp(`${api_key}-${domain}`);
-    if (!mailchimp_list.id) {
-      throw new Error("No mailchimp list set");
-    }
-    this.list_id = mailchimp_list.id;
+    this.list_id = mailchimp_list_id;
   }
 
   // Mailchimp API request

--- a/server/lib/middlewares/hull-client.js
+++ b/server/lib/middlewares/hull-client.js
@@ -4,7 +4,7 @@ import Hull from "hull";
 const shipToken = process.env.SHIP_TOKEN || "3095jv02939jfd";
 
 export default function (options) {
-  var _cache = [];
+  const _cache = [];
 
   function getCurrentShip(shipId, client, forceUpdate) {
     if (options.useCache) {

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -178,18 +178,15 @@ export default function oauth({
     client.utils.log("Start sync all operation");
     agent.removeAudiences()
     .then(agent.handleShipUpdate.bind(agent, false))
-    // in use case when hull user decides to sync all his/her userbase
-    // and then selects some filters to filter out some users.
-    // This is why we need to trigger sync off all users here.
-    // .then(agent.fetchSyncHullSegments.bind(this))
-    .then(() => {
-      // client.utils.log("Request the extract for segments", segments.length);
-      // if (segments.length == 0) {
-      return agent.requestExtract({});
-      // }
-      // return Promise.map(segments, segment => {
-      //   return agent.requestExtract({ segment });
-      // });
+    .then(agent.fetchSyncHullSegments.bind(agent))
+    .then(segments => {
+      client.utils.log("Request the extract for segments", segments.length);
+      if (segments.length == 0) {
+        return agent.requestExtract({});
+      }
+      return Promise.map(segments, segment => {
+        return agent.requestExtract({ segment });
+      });
     })
     .then(() => {
       res.end("ok");

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -171,15 +171,15 @@ export default function oauth({
     const { ship, client } = req.hull || {};
     const agent = new MailchimpAgent(ship, client, req, MailchimpClient);
 
+    client.utils.log("Start sync all operation");
     agent.removeAudiences()
     .then(agent.handleShipUpdate.bind(agent))
     .then(agent.fetchSyncHullSegments.bind(agent))
-    .then(segments => {
-      return Promise.all(segments.map(segment => {
-        return agent.getAudienceForSegment(segment).then(audience => {
-          return agent.requestExtract({ segment, audience });
-        });
-      }));
+    .each(segment => {
+      return agent.getAudienceForSegment(segment).then(audience => {
+        client.utils.log("Request extract for segment", segment.name);
+        return agent.requestExtract({ segment, audience });
+      });
     })
     .then(() => {
       res.end("ok");

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -112,7 +112,7 @@ export default function oauth({
       // for the ship mailchimp application and we need to ask for the permission
       // once again
       if (err.statusCode === 401) {
-        hull.utils.log('Mailchimp /lists query returned 401 - ApiKey is invalid');
+        hull.utils.log("Mailchimp /lists query returned 401 - ApiKey is invalid");
         hull.put(ship.id, {
           private_settings: { ...ship.private_settings, api_key: null }
         }).then(() => {
@@ -152,15 +152,12 @@ export default function oauth({
       };
       return res.render("sync.html", viewData);
     });
-
-
   }
 
   /**
-   * Sync all operation. It drops all
-   * @param  {[type]} req [description]
-   * @param  {[type]} res [description]
-   * @return {[type]}     [description]
+   * Sync all operation handler. It drops all Mailchimp Segments aka Audiences
+   * Creates them according to `segment_mapping` settings and triggers
+   * sync of all selected segments.
    */
   function handleSync(req, res) {
     const { ship, client } = req.hull || {};

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -20,9 +20,8 @@ export default function oauth({
   });
 
   function renderHome(req, res) {
-
     const { ship = {}, } = req.hull;
-    const { domain, api_key: apiKey } = ship.private_settings || {};
+    const { api_key: apiKey } = ship.private_settings || {};
     const redirect_uri = `https://${req.hostname}${req.baseUrl}${callbackUrl}?hullToken=${req.hull.hullToken}`;
     const viewData = {
       name,
@@ -89,37 +88,35 @@ export default function oauth({
 
   function renderSelect(req, res) {
     const { ship = {}, client: hull } = req.hull;
-    const { domain, api_key: apiKey, list_id, api_endpoint } = ship.private_settings || {};
+    const { api_key: apiKey, list_id, api_endpoint } = ship.private_settings || {};
     const viewData = {
       name,
       form_action: `https://${req.hostname}${req.baseUrl}${selectUrl}?hullToken=${req.hull.hullToken}`,
-      list_id: list_id
-    }
+      list_id
+    };
     rp({
       uri: `${api_endpoint}/3.0/lists`,
       qs: {
-        fields: 'lists.id,lists.name'
+        fields: "lists.id,lists.name"
       },
-      headers: { "Authorization": `OAuth ${apiKey}`, },
+      headers: { Authorization: `OAuth ${apiKey}`, },
       json: true
     }).then((data) => {
       viewData.mailchimp_lists = data.lists;
 
       return res.render("admin.html", viewData);
     }, (err) => {
-
       // if we got auth error let's clear api key and redirect to first step
       // of the ship installation - this is the case when user deleted the api key
       // for the ship mailchimp application and we need to ask for the permission
       // once again
-      if (err.statusCode == 401) {
+      if (err.statusCode === 401) {
         hull.put(ship.id, {
           private_settings: { ...ship.private_settings, api_key: null }
-        }).then((data) => {
+        }).then(() => {
           return res.redirect(`${req.baseUrl}${homeUrl}?hullToken=${req.hull.hullToken}`);
         });
       }
-
     });
   }
 
@@ -128,18 +125,16 @@ export default function oauth({
 
     hull.put(ship.id, {
       private_settings: { ...ship.private_settings, list_id: req.body.mailchimp_list }
-    }).then((data) => {
+    }).then(() => {
       return res.redirect(`${req.baseUrl}${syncUrl}?hullToken=${req.hull.hullToken}`);
     });
   }
 
   function renderSync(req, res) {
-    const { ship = {}, client: hull } = req.hull;
-    const { domain, api_key: apiKey, list_id, api_endpoint } = ship.private_settings || {};
     const viewData = {
       name,
       form_action: `https://${req.hostname}${req.baseUrl}${syncUrl}?hullToken=${req.hull.hullToken}`,
-    }
+    };
     return res.render("sync.html", viewData);
   }
 
@@ -154,13 +149,13 @@ export default function oauth({
     .then(segments => {
       return Promise.all(segments.map(segment => {
         return agent.getAudienceForSegment(segment).then(audience => {
-          return agent.requestExtract({segment, audience});
+          return agent.requestExtract({ segment, audience });
         });
       }));
-    }).then(promiseRes => {
-      res.end('handleSync');
+    })
+    .then(() => {
+      res.end("handleSync");
     });
-
   }
 
   const router = Router();

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -126,7 +126,6 @@ export default function oauth({
       json: true
     }).then((data) => {
       viewData.mailchimp_lists = data.lists;
-      console.log(viewData);
       return res.render("admin.html", viewData);
     }, mailchimpErrorHandler.bind(this, res, res, ship, hull));
   }

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -5,6 +5,7 @@ import oauth2Factory from "simple-oauth2";
 import rp from "request-promise";
 import MailchimpAgent from "./mailchimp-agent";
 import MailchimpClient from "./mailchimp-client";
+import Promise from "bluebird";
 
 export default function oauth({
   name, clientID, clientSecret,
@@ -168,7 +169,7 @@ export default function oauth({
   /**
    * Sync all operation handler. It drops all Mailchimp Segments aka Audiences
    * then creates them according to `segment_mapping` settings and triggers
-   * sync for all selected segments.
+   * sync for all users
    */
   function handleSync(req, res) {
     const { ship, client } = req.hull || {};
@@ -176,13 +177,19 @@ export default function oauth({
 
     client.utils.log("Start sync all operation");
     agent.removeAudiences()
-    .then(agent.handleShipUpdate.bind(agent))
-    .then(agent.fetchSyncHullSegments.bind(agent))
-    .each(segment => {
-      return agent.getAudienceForSegment(segment).then(audience => {
-        client.utils.log("Request extract for segment", segment.name);
-        return agent.requestExtract({ segment, audience });
-      });
+    .then(agent.handleShipUpdate.bind(agent, false))
+    // in use case when hull user decides to sync all his/her userbase
+    // and then selects some filters to filter out some users.
+    // This is why we need to trigger sync off all users here.
+    // .then(agent.fetchSyncHullSegments.bind(this))
+    .then(() => {
+      // client.utils.log("Request the extract for segments", segments.length);
+      // if (segments.length == 0) {
+      return agent.requestExtract({});
+      // }
+      // return Promise.map(segments, segment => {
+      //   return agent.requestExtract({ segment });
+      // });
     })
     .then(() => {
       res.end("ok");

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -88,14 +88,14 @@ export default function oauth({
 
   function renderSelect(req, res) {
     const { ship = {}, } = req.hull;
-    const { domain, api_key: apiKey, list_id } = ship.private_settings || {};
+    const { domain, api_key: apiKey, list_id, api_endpoint } = ship.private_settings || {};
     const viewData = {
       name,
       form_action: `https://${req.hostname}${req.baseUrl}${selectUrl}?hullToken=${req.hull.hullToken}`,
       list_id: list_id
     }
     rp({
-      uri: `https://${domain}.api.mailchimp.com/3.0/lists`,
+      uri: `${api_endpoint}/3.0/lists`,
       qs: {
         fields: 'lists.id,lists.name'
       },

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -34,18 +34,21 @@ export default function oauth({
       }).then(() => {
         return res.redirect(`${req.baseUrl}${homeUrl}?hullToken=${req.hull.hullToken}`);
       });
+    } else {
+      // TODO add an error page template to display uncaught errors
+      res.status(500).end(`Error: ${err.statusCode} -- ${err.message}`);
     }
   }
 
   function renderHome(req, res) {
     const { ship = {}, } = req.hull;
-    const { api_key: apiKey, mailchimp_list_id: mailchimpListId } = ship.private_settings || {};
+    const { api_key: apiKey, mailchimp_list_id: mailchimpListId, api_endpoint: apiEndpoint } = ship.private_settings || {};
     const redirect_uri = `https://${req.hostname}${req.baseUrl}${callbackUrl}?hullToken=${req.hull.hullToken}`;
     const viewData = {
       name,
       url: oauth2.authCode.authorizeURL({ redirect_uri })
     };
-    if (!apiKey) {
+    if (!apiKey || !apiEndpoint) {
       return res.render("login.html", viewData);
     }
 

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -251,7 +251,7 @@ export default class SegmentSyncAgent {
    * @param  {Object} segment - A segment
    * @param  {Object} audience - An audience
    * @param  {String} format - csv or json
-   * @return {undefined}
+   * @return {Promise}
    */
   requestExtract({ segment, audience, format = "csv" }) {
     const { hostname } = this.req;
@@ -266,10 +266,16 @@ export default class SegmentSyncAgent {
 
     const fields = this._getExtractFields();
 
-    const query = segment.query;
-
-    const params = { query, format, url, fields };
-    return this.hull.post("extract/user_reports", params);
+    return (() => {
+      if (segment.query) {
+        return Promise.resolve(segment);
+      }
+      return this.hull.get(segment.id);
+    })()
+    .then(({ query }) => {
+      const params = { query, format, url, fields };
+      return this.hull.post("extract/user_reports", params);
+    });
   }
 
 

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -106,7 +106,7 @@ export default class SegmentSyncAgent {
    */
   shouldSyncUser(user) {
     const segmentIds = this.getPrivateSetting("synchronized_segments") || [];
-    if (segmentIds.length == 0) {
+    if (segmentIds.length === 0) {
       return true;
     }
     return _.intersection(segmentIds, user.segment_ids).length > 0;
@@ -218,8 +218,7 @@ export default class SegmentSyncAgent {
    * @return {undefined}
    */
   handleSegmentUpdate(segment) {
-    return this.shouldSyncUser(user) &&
-      this.getOrCreateAudienceForSegment(segment);
+    return this.getOrCreateAudienceForSegment(segment);
   }
 
   /**
@@ -326,7 +325,7 @@ export default class SegmentSyncAgent {
    */
   getAudiencesBySegmentId() {
     if (this._audiences) {
-      return Promise.resolve(this._audiences)
+      return Promise.resolve(this._audiences);
     }
     return this.fetchAudiencesBySegmentId().then(audiences => {
       this._audiences = audiences;
@@ -344,9 +343,9 @@ export default class SegmentSyncAgent {
 
   fetchSyncHullSegments() {
     const segmentIds = this.getPrivateSetting("synchronized_segments") || [];
-    return this.hull.get('segments', { where: {
+    return this.hull.get("segments", { where: {
       id: { $in: segmentIds }
-    }});
+    } });
   }
 
   fetchAudiencesBySegmentId() {

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -227,11 +227,14 @@ export default class SegmentSyncAgent {
    * @return {undefined}
    */
   handleSegmentDelete(segment) {
-    return this.getAudienceForSegment(segment).then(
-      (audience) => {
-        return audience && this.deleteAudience(audience.id, segment.id);
-      }
-    ).catch(err => console.warn("error deleting audience: ", err));
+    // since the deleted segment is not returned by Hull `/segments` API endpoint
+    // we cannot use fetchAudiencesBySegmentId method, we need to use saved
+    // segments to audiences mapping
+    const mapping = this.getPrivateSetting("segment_mapping") || {};
+    const audienceId = mapping[segment.id] || null;
+
+    return audienceId && this.deleteAudience(audienceId, segment.id)
+    .catch(err => console.warn("error deleting audience: ", err));
   }
 
   _getExtractFields() {

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -331,7 +331,7 @@ export default class SegmentSyncAgent {
     return ps.wait(request({ url })
       .pipe(decoder)
       .pipe(batch)
-      .pipe(ps.map({ concurrent: 1 }, callback))
+      .pipe(ps.map({ concurrent: 2 }, callback))
     );
   }
 

--- a/server/views/admin.html
+++ b/server/views/admin.html
@@ -24,9 +24,9 @@
                   <div class="col-sm-9">
                     <select class="form-control" name="mailchimp_list" placeholder="Pick Mailchimp List">
                       <%for (var i = 0; i < mailchimp_lists.length; i++) {
-                        var mailchimp_list = mailchimp_lists[i];
+                        var ml = mailchimp_lists[i];
                          %>
-                      <option<% if (mailchimp_list.id == list_id) {-%> selected<%}-%> value="<%=mailchimp_list.id%>"><%=mailchimp_list.name%></option>
+                      <option<% if (mailchimp_list && ml.id === mailchimp_list.id) {-%> selected<%}-%> value="<%=ml.id%>"><%=ml.name%></option>
                       <%}-%>
                     </select>
                   </div>

--- a/server/views/admin.html
+++ b/server/views/admin.html
@@ -2,6 +2,7 @@
 <head>
   <title>Hull <%= name %></title>
   <link rel="stylesheet" href="//dd04rofzygnm0.cloudfront.net/releases/master/865f04865d2448286626bac92c518a8f8ea8bafe/stylesheets/neue.css" />
+  <link rel="stylesheet" href="/auth.css" />
 </head>
 <body>
   <div class="row">
@@ -18,8 +19,9 @@
             <div class="media-body pt-1">
               <h4 class="m-0 text-muted">Connected to Mailchimp</h4>
               <form action="<%=form_action%>" method="post">
+                <h5 class="mb-1">Choose the list that will receive Hull users</h5>
                 <div class="row">
-                  <div class="col-md-10">
+                  <div class="col-sm-9">
                     <select class="form-control" name="mailchimp_list" placeholder="Pick Mailchimp List">
                       <%for (var i = 0; i < mailchimp_lists.length; i++) {
                         var mailchimp_list = mailchimp_lists[i];
@@ -28,8 +30,8 @@
                       <%}-%>
                     </select>
                   </div>
-                  <div class="col-md-2">
-                    <button class='btn btn-rounded btn-block btn-primary'>
+                  <div class="col-sm-3">
+                    <button class='btn btn-block btn-primary'>
                       Select
                     </button>
                   </div>
@@ -46,29 +48,5 @@
       window.location.reload();
   }
   </script>
-  <style type="text/css" media="screen">
-    .media{
-      width: 260px;
-      margin: 0 auto;
-    }
-    .check i.icon {
-      color: rgba(75, 222, 122, 0.52);
-      font-size: 2pc;
-      position: relative;
-      top: -11px;
-      left: 3px;
-    }
-    .check.valid {
-      border-color: rgba(75, 222, 122, 0.52);
-    }
-    .check {
-      border-radius: 100px;
-      border: 2px solid transparent;
-      padding: 0 5px;
-      height: 37px;
-      width: 37px;
-      position: relative;
-    }
-  </style>
 </body>
 </html>

--- a/server/views/admin.html
+++ b/server/views/admin.html
@@ -22,11 +22,11 @@
                 <h5 class="mb-1">Choose the list that will receive Hull users</h5>
                 <div class="row">
                   <div class="col-sm-9">
-                    <select class="form-control" name="mailchimp_list" placeholder="Pick Mailchimp List">
+                    <select class="form-control" name="mailchimp_list_id" placeholder="Pick Mailchimp List">
                       <%for (var i = 0; i < mailchimp_lists.length; i++) {
                         var ml = mailchimp_lists[i];
                          %>
-                      <option<% if (mailchimp_list && ml.id === mailchimp_list.id) {-%> selected<%}-%> value="<%=ml.id%>"><%=ml.name%></option>
+                      <option<% if (ml.id === mailchimp_list_id) {-%> selected<%}-%> value="<%=ml.id%>"><%=ml.name%></option>
                       <%}-%>
                     </select>
                   </div>

--- a/server/views/admin.html
+++ b/server/views/admin.html
@@ -17,9 +17,24 @@
             </div>
             <div class="media-body pt-1">
               <h4 class="m-0 text-muted">Connected to Mailchimp</h4>
-              <p>
-                <a href="<%=list_url%>" target="_blank"> View your lists</a>
-              </p>
+              <form action="<%=form_action%>" method="post">
+                <div class="row">
+                  <div class="col-md-10">
+                    <select class="form-control" name="mailchimp_list" placeholder="Pick Mailchimp List">
+                      <%for (var i = 0; i < mailchimp_lists.length; i++) {
+                        var mailchimp_list = mailchimp_lists[i];
+                         %>
+                      <option<% if (mailchimp_list.id == list_id) {-%> selected<%}-%> value="<%=mailchimp_list.id%>"><%=mailchimp_list.name%></option>
+                      <%}-%>
+                    </select>
+                  </div>
+                  <div class="col-md-2">
+                    <button class='btn btn-rounded btn-block btn-primary'>
+                      Select
+                    </button>
+                  </div>
+                </div>
+              </form>
             </div>
           </div>
         </div>

--- a/server/views/login.html
+++ b/server/views/login.html
@@ -15,8 +15,7 @@
               <h5 class="uppercase text-accented underlined mb-1">Connect to <%= name %></h5>
               <p class="text-muted mb-1">
                 <span>
-                  Please enter list ID on the left (<a target='_blank' href='http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id'>How to find your Mailchimp list ID</a>) <br> then
-                  give Hull permission to access your <%= name %> Account
+                  Click button below to give Hull permission to access your <%= name %> Account
                 </span>
               </p>
               <a href="<%=url%>" target="_blank" id='login' class='btn btn-rounded btn-block btn-primary'>

--- a/server/views/sync.html
+++ b/server/views/sync.html
@@ -25,7 +25,7 @@ Choose one or more Filtered Segments on the sidebar to limit synced users to a s
               </p>
               <button class='mb-1 btn btn-block btn-primary'
                 data-action="<%=form_action%>"
-                data-confirm="<%=mailchimp_list.name%>">Sync all users and segments</button>
+                data-confirm="<%=mailchimp_list_name%>">Sync all users and segments</button>
               <!-- link to list selection is disabled. Due to current implementation -->
               <!-- it is not possible to change the mailchimp list -->
               <!-- <a href="<%=select_url%>">Return to Mailchimp List selection</a> -->

--- a/server/views/sync.html
+++ b/server/views/sync.html
@@ -2,6 +2,8 @@
 <head>
   <title>Hull <%= name %></title>
   <link rel="stylesheet" href="//dd04rofzygnm0.cloudfront.net/releases/master/865f04865d2448286626bac92c518a8f8ea8bafe/stylesheets/neue.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.css" />
+  <link rel="stylesheet" href="/auth.css" />
 </head>
 <body>
   <div class="row">
@@ -17,37 +19,14 @@
             </div>
             <div class="media-body pt-1">
               <h4 class="m-0 text-muted">Connected to Mailchimp</h4>
-              <form action="<%=form_action%>" method="post">
-                <div class="row">
-                  <div class="col-md-10">
-                    The Mailchimp integration is set up correctly. Users are now sent to Mailchimp when they are updated. If you haven’t done it before or you want to reset everything, click the “Sync all users and segments” button below to empty and refill the list.
+              <p class="mb-1">
+                The Mailchimp integration is set up correctly. Users are now sent to Mailchimp when they are updated. If you haven’t done it before or you want to reset everything, click the “Sync all users and segments” button below to empty and refill the list.
 Choose one or more Filtered Segments on the sidebar to limit synced users to a subset of your database.
-                  </div>
-                  <div class="col-md-2">
-                    <input type="button" class='btn btn-rounded btn-block btn-primary' data-toggle="modal" data-target="#myModal" value="Sync all users and segments">
-                  </div>
-                </div>
-                <!-- Modal -->
-                <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-                  <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title" id="myModalLabel">Modal title</h4>
-                      </div>
-                      <div class="modal-body">
-                        ...
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                        <button class='btn btn-rounded btn-block btn-primary' data-toggle="modal" data-target="#myModal">
-                          Confirm
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </form>
+              </p>
+              <button class='mb-1 btn btn-block btn-primary'
+                data-action="<%=form_action%>"
+                data-confirm="<%=list_name%>">Sync all users and segments</button>
+              <a href="<%=select_url%>">Return to Mailchimp List selection</a>
             </div>
           </div>
         </div>
@@ -55,30 +34,33 @@ Choose one or more Filtered Segments on the sidebar to limit synced users to a s
     </div>
   </div>
   <style type="text/css" media="screen">
-    .media{
-      width: 260px;
-      margin: 0 auto;
-    }
-    .check i.icon {
-      color: rgba(75, 222, 122, 0.52);
-      font-size: 2pc;
-      position: relative;
-      top: -11px;
-      left: 3px;
-    }
-    .check.valid {
-      border-color: rgba(75, 222, 122, 0.52);
-    }
-    .check {
-      border-radius: 100px;
-      border: 2px solid transparent;
-      padding: 0 5px;
-      height: 37px;
-      width: 37px;
-      position: relative;
-    }
   </style>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"></script>
+  <script>
+    $(function() {
+
+      $("[data-confirm]").click(function() {
+        var listName = $(this).attr('data-confirm');
+        var actionUrl = $(this).attr('data-action');
+        swal({
+          title: "Sync all users and segments",
+          text: "You are going to resync Mailchimp with Hull. This will empty the list you picked ("
+            + listName + "). This can generate a lot of traffic. Are you sure?",
+          type: "warning",
+          showCancelButton: true,
+          confirmButtonColor: "#DD6B55",
+          confirmButtonText: "Yes, sync it!",
+          closeOnConfirm: false
+        }, function(isConfirm) {
+          if (isConfirm) {
+            $.post(actionUrl);
+            swal("Sync started", "The Mailchimp list ("
+            + listName + ") will be synced shortly.", "success");
+          }
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/server/views/sync.html
+++ b/server/views/sync.html
@@ -25,7 +25,7 @@ Choose one or more Filtered Segments on the sidebar to limit synced users to a s
               </p>
               <button class='mb-1 btn btn-block btn-primary'
                 data-action="<%=form_action%>"
-                data-confirm="<%=list_name%>">Sync all users and segments</button>
+                data-confirm="<%=mailchimp_list.name%>">Sync all users and segments</button>
               <a href="<%=select_url%>">Return to Mailchimp List selection</a>
             </div>
           </div>

--- a/server/views/sync.html
+++ b/server/views/sync.html
@@ -1,0 +1,84 @@
+<html>
+<head>
+  <title>Hull <%= name %></title>
+  <link rel="stylesheet" href="//dd04rofzygnm0.cloudfront.net/releases/master/865f04865d2448286626bac92c518a8f8ea8bafe/stylesheets/neue.css" />
+</head>
+<body>
+  <div class="row">
+    <div class="col-md-4 col-md-offset-4 col-sm-offset-2 col-sm-8 col-xs-offset-1 col-xs-10 mt-2 panel">
+      <div class="panel-body">
+        <div class="mb-1">
+          <h1 class="mb-0 mt-05  text-center"><i class="icon icon-hull" style="font-size:64px;"></i></h1>
+          <div class="mb-1 media">
+            <div class="media-left">
+              <div class="media-object pr-1 pt-05">
+                <div class="check valid"><i class="icon icon-valid"></i></div>
+              </div>
+            </div>
+            <div class="media-body pt-1">
+              <h4 class="m-0 text-muted">Connected to Mailchimp</h4>
+              <form action="<%=form_action%>" method="post">
+                <div class="row">
+                  <div class="col-md-10">
+                    The Mailchimp integration is set up correctly. Users are now sent to Mailchimp when they are updated. If you haven’t done it before or you want to reset everything, click the “Sync all users and segments” button below to empty and refill the list.
+Choose one or more Filtered Segments on the sidebar to limit synced users to a subset of your database.
+                  </div>
+                  <div class="col-md-2">
+                    <input type="button" class='btn btn-rounded btn-block btn-primary' data-toggle="modal" data-target="#myModal" value="Sync all users and segments">
+                  </div>
+                </div>
+                <!-- Modal -->
+                <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title" id="myModalLabel">Modal title</h4>
+                      </div>
+                      <div class="modal-body">
+                        ...
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                        <button class='btn btn-rounded btn-block btn-primary' data-toggle="modal" data-target="#myModal">
+                          Confirm
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <style type="text/css" media="screen">
+    .media{
+      width: 260px;
+      margin: 0 auto;
+    }
+    .check i.icon {
+      color: rgba(75, 222, 122, 0.52);
+      font-size: 2pc;
+      position: relative;
+      top: -11px;
+      left: 3px;
+    }
+    .check.valid {
+      border-color: rgba(75, 222, 122, 0.52);
+    }
+    .check {
+      border-radius: 100px;
+      border: 2px solid transparent;
+      padding: 0 5px;
+      height: 37px;
+      width: 37px;
+      position: relative;
+    }
+  </style>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/server/views/sync.html
+++ b/server/views/sync.html
@@ -26,7 +26,9 @@ Choose one or more Filtered Segments on the sidebar to limit synced users to a s
               <button class='mb-1 btn btn-block btn-primary'
                 data-action="<%=form_action%>"
                 data-confirm="<%=mailchimp_list.name%>">Sync all users and segments</button>
-              <a href="<%=select_url%>">Return to Mailchimp List selection</a>
+              <!-- link to list selection is disabled. Due to current implementation -->
+              <!-- it is not possible to change the mailchimp list -->
+              <!-- <a href="<%=select_url%>">Return to Mailchimp List selection</a> -->
             </div>
           </div>
         </div>

--- a/tests/create-audience-tests.js
+++ b/tests/create-audience-tests.js
@@ -1,0 +1,73 @@
+/* global describe, it */
+const assert = require("assert");
+import Promise from "bluebird";
+import sinon from "sinon";
+
+import MailchimpAgent from "../server/lib/mailchimp-agent";
+
+
+describe("MailchimpAgent", () => {
+  describe("createAudience", () => {
+
+    it(`should return audience when there is an exisiting static segment in mailchimp`, () => {
+
+      class MailchimpClientStub {
+        constructor() {
+          this.client = {
+            batch() {
+              return new Promise.resolve({ segments: [
+                { name: "testSegment" }
+              ] });
+            }
+          }
+        }
+      }
+
+      const mailchimpAgent = new MailchimpAgent({}, {}, {}, MailchimpClientStub);
+
+      return mailchimpAgent.createAudience({ name: "testSegment" })
+        .then(res => {
+          assert.deepEqual(res, { name: "testSegment" });
+        });
+    });
+
+    it(`should create and return an audience when there is no an exisiting static segment`, () => {
+
+      class MailchimpClientStub {
+        constructor() {
+          this.client = {
+            batch() {
+              return new Promise.resolve({ segments: [] });
+            }
+          }
+        }
+      }
+
+
+      const mailchimpAgent = new MailchimpAgent({}, {}, {}, MailchimpClientStub);
+
+      mailchimpAgent.request = sinon.stub();
+      mailchimpAgent.saveAudienceMapping = sinon.stub();
+
+      mailchimpAgent.request.onCall(0)
+      .returns(new Promise.resolve({
+        id: 123,
+        name: 'test',
+        type: 'static'
+      }));
+
+      mailchimpAgent.saveAudienceMapping.onCall(0)
+        .returns((new Promise.resolve([])))
+
+      return mailchimpAgent.createAudience({ name: "testSegment" }, false)
+        .then(res => {
+          assert.deepEqual(res, {
+            id: 123,
+            isNew: true,
+            type: "static",
+            name: "test"
+          });
+        });
+    });
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,4 @@
+require("babel-register")({ presets: ["es2015", "stage-0"] });
+
+require("./mailchimp-agent-tests");
+require("./ship-update");

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,4 +1,5 @@
 require("babel-register")({ presets: ["es2015", "stage-0"] });
 
 require("./mailchimp-agent-tests");
+require("./create-audience-tests");
 require("./ship-update");

--- a/tests/mailchimp-agent-tests.js
+++ b/tests/mailchimp-agent-tests.js
@@ -1,0 +1,86 @@
+/* global describe, it */
+const assert = require("assert");
+import Promise from "bluebird";
+
+import MailchimpAgent from "../server/lib/mailchimp-agent";
+
+
+describe("MailchimpAgent", () => {
+  describe("fetchAudiencesBySegmentId", () => {
+    const tests = [
+      {
+        caseDescription: "one hull segment and mapped mailchimp segment",
+        hullSegments: [{ name: "testSegment", id: "hullSegmentId" }],
+        mailchimpSegments: { segments: [
+          { name: "Test Mailchimp Segment", id: "MailchimpSegmentId" }
+        ] },
+        shipPrivateSettings: {
+          segment_mapping: {
+            hullSegmentId: "MailchimpSegmentId"
+          }
+        },
+        result: {
+          hullSegmentId: {
+            segment: { name: "testSegment", id: "hullSegmentId" },
+            audience: { name: "Test Mailchimp Segment", id: "MailchimpSegmentId" }
+          }
+        }
+      },
+      {
+        caseDescription: "two hull segments without mapped mailchimp segment",
+        hullSegments: [
+          { name: "testSegment", id: "hullSegmentId" },
+          { name: "Second Test Segment", id: "secondHullSegmentId" }
+        ],
+        mailchimpSegments: { segments: [] },
+        shipPrivateSettings: {
+          segment_mapping: {
+            hullSegmentId: "MailchimpSegmentId"
+          }
+        },
+        result: {
+          hullSegmentId: {
+            segment: { name: "testSegment", id: "hullSegmentId" },
+            audience: undefined
+          },
+          secondHullSegmentId: {
+            segment: { name: "Second Test Segment", id: "secondHullSegmentId" },
+            audience: undefined
+          }
+        }
+      },
+    ];
+
+    tests.forEach(function eachTestCase(test) {
+      it(`should handle following case: ${test.caseDescription}`, () => {
+        class MailchimpClientStub {
+          request() {
+            return new Promise.resolve(test.mailchimpSegments);
+          }
+        }
+
+        const hullStub = {
+          utils: {
+            log() {}
+          },
+          get() {
+            return test.hullSegments;
+          }
+        };
+
+        const reqStub = {};
+
+        const shipStub = {
+          private_settings: test.shipPrivateSettings
+        };
+
+        const mailchimpAgent = new MailchimpAgent(shipStub, hullStub, reqStub, MailchimpClientStub);
+
+        return mailchimpAgent.fetchAudiencesBySegmentId()
+        .then(res => {
+          assert.deepEqual(res, test.result);
+        });
+      });
+    });
+  });
+});

--- a/tests/ship-update.js
+++ b/tests/ship-update.js
@@ -1,0 +1,32 @@
+/* global describe, it */
+const request = require("supertest");
+
+const Server = require("../server").Server;
+
+
+describe("When handling user update/create event", function describeCase() {
+  this.timeout(10000);
+
+  it("should respond with ok", (done) => {
+    request(Server())
+      .post("/notify")
+      .query({
+        organization: "5c2061e1.hullapp.io",
+        secret: "167ae77fbc3ea35065d9cf489bfdeec2",
+        ship: "5777eb1e9d2f17c0b2001516"
+      })
+      .send({
+        Type: "Notification",
+        MessageId: "ecbb5fb4-c778-5b54-9d5f-104ff7e7ea69",
+        TopicArn: "arn:aws:sns:us-east-1:029046039368:notifications-52e65d490f1d42726a0000d9",
+        Subject: "ship:update",
+        Message: "{\"id\":\"5777eb1e9d2f17c0b2001516\",\"updated_at\":\"2016-07-09T17:03:26Z\",\"created_at\":\"2016-07-02T16:26:12Z\",\"name\":\"New Ship\",\"description\":null,\"extra\":{},\"stats\":{},\"tags\":[],\"picture\":\"https://502385f9.ngrok.io/picture.png\",\"type\":\"ship\",\"starts_at\":null,\"ends_at\":null,\"homepage_url\":\"https://5c2061e1.hullapp.io/ships/5777eb1e9d2f17c0b2001516\",\"manifest_url\":\"https://a2f35c6c.ngrok.io/manifest.json\",\"privacy_policy_url\":null,\"terms_of_service_url\":null,\"manifest\":{\"name\":\"Mailchimp\",\"description\":\"Synchronize Segments as Mailchimp Lists\",\"picture\":\"picture.png\",\"version\":\"0.0.1\",\"tags\":[\"outgoing\",\"batch\"],\"private_settings\":[{\"name\":\"synchronized_segments\",\"title\":\"Filtered Segments\",\"description\":\"Only sync users in at least one these segments (Empty to send everyone)\",\"type\":\"array\",\"format\":\"segment\"},{\"name\":\"list_id\",\"title\":\"Mailchimp List ID\",\"description\":\"Mailchimp List ID selected by user\",\"type\":\"string\",\"format\":\"hidden\"},{\"name\":\"api_key\",\"title\":\"API Key\",\"description\":\"Token or API Key\",\"type\":\"string\",\"format\":\"hidden\"},{\"name\":\"domain\",\"title\":\"API Domain\",\"description\":\"Mailchimp API Domain\",\"type\":\"string\",\"format\":\"hidden\"},{\"name\":\"segment_mapping\",\"type\":\"object\",\"properties\":{},\"format\":\"hidden\"}],\"readme\":\"readme.md\",\"admin\":\"/auth/\",\"ui\":false,\"subscriptions\":[{\"url\":\"/notify\"}]},\"settings\":{},\"source_url\":\"https://a2f35c6c.ngrok.io/\",\"translations\":{},\"index\":\"https://a2f35c6c.ngrok.io/\",\"resources\":{}}",
+        Timestamp: "2016-07-09T17:03:27.714Z",
+        SignatureVersion: "1",
+        Signature: "DgKlL9614H670vY5kDhWOrhSGW5rTvdIGiJI8dCokpgdoSCd3tsKpX7Zy/2FDdwl5/+RPfHt/6s5ilhQRVdHzdsQBbS2i4ZqR4/a9Y5wx4qSLVuHE0Vb2MT64kQg9EPeCZn/MI1SWZoP1gIsjbOdAmrj82CHXVW2DynaeyU5h335wHKMjnjTrJWcdIcz0/vvUv8Gga8agwspOmIIu2mGyFkGR4ux2WS95XbRjplMI6hbJFaVRFXSXHTUxQBvTjcYhNIc5O2IBPdcuCS/6TkS2+/ComwljmWobERXmtGPi8Lr0lwDfnPuuU6qQAaeNSGcllHvypWEOjgynKlVkLu3Kw==",
+        SigningCertURL: "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-bb750dd426d95ee9390147a5624348ee.pem",
+        UnsubscribeURL: "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:029046039368:notifications-52e65d490f1d42726a0000d9:4f38b2ef-e4fa-4970-9184-df9833137339"
+      })
+      .expect("ok", done);
+  });
+});


### PR DESCRIPTION
- 3 admin panels steps: auth with mailchimp, select the list (moved from sidebar) and optionally trigger the "sync all" operation (added sweetalert modals to match hull dashboard look&feel)
- changed the way information about selected mailchimp list is stored (from list_id integer to an object with both id and name) - since we need name for admin panels - I wanted to avoid unnecessary mailchimp api calls
- moved mailchimp-client dependency outside of mailchimp-agent to enable unit testing the latter
- `shouldSyncSegment` strategy changed to `shouldSyncUser` (since we need to sync all segments, but only the users from one of the filtered segments)
- fixed `handleSegmentDelete` method
- added example automatic tests
- added `babel-watch` script
- updated `mailchimp-api-v3` to include fix for reported problem
- linted everything