### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.0",
     "mocha": "^2.5.2",
+    "proxyquire": "^1.7.10",
     "sinon": "^1.17.4",
     "supertest": "^1.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "batch-stream": "^0.1.3",
     "bluebird": "^3.3.5",
     "body-parser": "^1.15.1",
+    "bottleneck": "^1.12.0",
     "csv-stream": "^0.1.3",
     "ejs": "^2.4.1",
     "eslint": "^2.9.0",

--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,6 @@ import bodyParser from "body-parser";
 import fetchShip from "./lib/middlewares/fetch-ship";
 import MailchimpAgent from "./lib/mailchimp-agent";
 import MailchimpClient from "./lib/mailchimp-client";
-import { randomBytes } from "crypto";
 
 import oauth from "./lib/oauth-client";
 

--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,7 @@ export function Server({ hostSecret }) {
       return res.status(403).send("Ship is not configured properly");
     }
 
-    client.logger.info("request.batch.start");
+    client.logger.info("request.batch.start", req.body);
     res.end("ok");
     return agent.handleExtract(req.body, users => {
       client.logger.info("request.batch.parseChunk", users.length);

--- a/server/index.js
+++ b/server/index.js
@@ -55,7 +55,7 @@ export function Server({ hostSecret }) {
     return agent.handleExtract(req.body, users => {
       client.logger.info("request.batch.parseChunk", users.length);
       const filteredUsers = users.filter(agent.shouldSyncUser.bind(agent));
-
+      client.logger.info("request.batch.filteredUsers", filteredUsers.length);
       return agent.addUsersToAudiences(filteredUsers);
     }).then(() => {
       client.logger.info("request.batch.end");

--- a/server/index.js
+++ b/server/index.js
@@ -56,7 +56,7 @@ export function Server({ hostSecret }) {
 
       const filteredUsers = users.filter((user) => {
         return !_.isEmpty(user.email)
-          && agent.shouldSyncUser(agent);
+          && agent.shouldSyncUser(user);
       });
 
       const usersToRemove = users.filter((user) => {

--- a/server/lib/limiter.js
+++ b/server/lib/limiter.js
@@ -5,8 +5,10 @@ import Bottleneck from "bottleneck";
  * http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/#toomanyrequests
  * we need to throttle our requesting client.
  *
- * The limit is applied per API KEY basis, so we use the Cluster feature:
+ * The limit is applied per API KEY, so we use the Cluster feature:
  * https://github.com/SGrondin/bottleneck#cluster
+ * and set it lower than allowed since there are now some queries from admin
+ * panel done outside the MailchimpClient class
  */
-const limiter = new Bottleneck.Cluster(10);
+const limiter = new Bottleneck.Cluster(8);
 export default limiter;

--- a/server/lib/limiter.js
+++ b/server/lib/limiter.js
@@ -1,0 +1,12 @@
+import Bottleneck from "bottleneck";
+
+/**
+ * Since Mailchimp has maximum connection limit:
+ * http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/#toomanyrequests
+ * we need to throttle our requesting client.
+ *
+ * The limit is applied per API KEY basis, so we use the Cluster feature:
+ * https://github.com/SGrondin/bottleneck#cluster
+ */
+const limiter = new Bottleneck.Cluster(10);
+export default limiter;

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -279,8 +279,14 @@ export default class MailchimpList extends SyncAgent {
       .then(responses => {
         return _.uniqBy(responses, "email_address").map((mc) => {
           const user = _.find(usersToAdd, { email: mc.email_address });
-          // Update user's mailchimp/* traits
-          return this.updateUser(user, mc);
+          // TODO an user = undefined here this is a quick fix
+          if (user) {
+            // Update user's mailchimp/* traits
+            return this.updateUser(user, mc);
+          } else {
+            this.hull.utils.log("addUsersToAudiences.userNotFound", mc.email_address);
+          }
+          return Promise.resolve();
         });
       });
   }

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -268,7 +268,7 @@ export default class MailchimpList extends SyncAgent {
           return [];
         }
         return this.request(batch);
-      })
+      }, (err) => this.hull.logger.info("error.addUsersToAudiences", err))
       .then(responses => {
         return _.uniqBy(responses, "email_address").map((mc) => {
           const user = _.find(usersToAdd, { email: mc.email_address });

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -385,7 +385,7 @@ export default class MailchimpList extends SyncAgent {
   fetchAudiences() {
     return this.request({
       path: "segments",
-      query: { type: "static", count: 100 }
+      body: { type: "static", count: 250 }
     })
     .then(
       ({ segments }) => segments,

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -261,7 +261,7 @@ export default class MailchimpList extends SyncAgent {
         return this.request(batch);
       }, (err) => this.hull.logger.info("error.addUsersToAudiences", err))
       .then(responses => {
-        const errors = _.reject(responses, "email_address")
+        const errors = _.reject(responses, "email_address");
         const uniqSuccess = _.filter(_.uniqBy(responses, "email_address"), "email_address");
         this.hull.logger.info("addUsersToAudiences.update", {
           responses: responses.length,

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -232,7 +232,7 @@ export default class MailchimpList extends SyncAgent {
           method: "delete",
           path: `/lists/${listId}/segments/${segment.id}`
         });
-      });
+      }, { concurrency: 3 });
   }
 
   /**

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -248,7 +248,7 @@ export default class MailchimpList extends SyncAgent {
         const batch = usersToAdd.reduce((ops, user) => {
           user.segment_ids.map(segmentId => {
             const { audience } = audiences[segmentId] || {};
-            this.hull.logger.info("addUsersToAudiences.op", user.email, audience.id);
+            this.hull.logger.info("addUsersToAudiences.op", user.email, audience.id, user.segment_ids);
             return ops.push({
               body: { email_address: user.email, status: "subscribed" },
               method: "post",

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -92,14 +92,15 @@ export default class MailchimpList extends SyncAgent {
     this.hull.utils.log("createAudience");
     const listId = this.getClient().list_id;
     const rawClient = this.getClient().client;
-    return rawClient.batch({
+    return rawClient.request({
       path: `/lists/${listId}/segments`,
       method: "get",
       query: {
-        count: 10000,
-        type: "static"
+        count: 250,
+        type: "static",
+        fields: "segments.name"
       }
-    }, { verbose: true }).then((res) => {
+    }).then((res) => {
       const existingSegment = res.segments.filter(s => s.name === segment.name);
       this.hull.utils.log("createAudience.existingSegment", existingSegment);
       if (existingSegment.length > 0) {

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -262,7 +262,10 @@ export default class MailchimpList extends SyncAgent {
       }, (err) => this.hull.logger.info("error.addUsersToAudiences", err))
       .then(responses => {
         this.hull.logger.info("addUsersToAudiences.update", responses.length);
-        return Promise.all(_.uniqBy(responses, "email_address").map((mc) => {
+        const errors = _.reject(responses, "email_address")
+        const uniqSuccess = _.filter(_.uniqBy(responses, "email_address"), "email_address");
+        errors.map((e) => this.hull.logger.info.bind(this.hull.logger, "addUsersToAudiences.responseError"));
+        return Promise.all(uniqSuccess.map((mc) => {
           this.hull.logger.info("addUsersToAudiences.updateUser", mc.email_address);
           const user = _.find(usersToAdd, { email: mc.email_address });
           if (user) {

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -266,7 +266,7 @@ export default class MailchimpList extends SyncAgent {
         return this.request(batch);
       }, (err) => this.hull.logger.info("error.addUsersToAudiences", err))
       .then(responses => {
-        return Promise.all(_.uniqBy(responses, "email_address").map((mc) => {
+        return Promise.map(_.uniqBy(responses, "email_address").map((mc) => {
           const user = _.find(usersToAdd, { email: mc.email_address });
           if (user) {
             // Update user's mailchimp/* traits

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -261,9 +261,13 @@ export default class MailchimpList extends SyncAgent {
         return this.request(batch);
       }, (err) => this.hull.logger.info("error.addUsersToAudiences", err))
       .then(responses => {
-        this.hull.logger.info("addUsersToAudiences.update", responses.length);
         const errors = _.reject(responses, "email_address")
         const uniqSuccess = _.filter(_.uniqBy(responses, "email_address"), "email_address");
+        this.hull.logger.info("addUsersToAudiences.update", {
+          responses,
+          uniqSuccess,
+          errors
+        });
         errors.map((e) => this.hull.logger.info.bind(this.hull.logger, "addUsersToAudiences.responseError"));
         return Promise.all(uniqSuccess.map((mc) => {
           this.hull.logger.info("addUsersToAudiences.updateUser", mc.email_address);

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -226,7 +226,7 @@ export default class MailchimpList extends SyncAgent {
 
     this.hull.logger.info("removeAudiences");
     return this.fetchAudiences()
-      .map(segments => {
+      .map(segment => {
         return rawClient.request({
           method: "delete",
           path: `/lists/${listId}/segments/${segment.id}`

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -385,7 +385,7 @@ export default class MailchimpList extends SyncAgent {
   fetchAudiences() {
     return this.request({
       path: "segments",
-      body: { type: "static", count: 250 }
+      query: { type: "static", count: 250 }
     })
     .then(
       ({ segments }) => segments,

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -123,8 +123,8 @@ export default class MailchimpList extends SyncAgent {
             return Object.assign({ isNew: true }, audience);
           });
         });
-      }, (err) => this.hull.logger.info("Error in createAudience", err));
-    });
+      });
+    }, (err) => this.hull.logger.info("Error in createAudience", err));
   }
 
   // Deletes an audience (aka Mailchimp Segment)

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -248,6 +248,7 @@ export default class MailchimpList extends SyncAgent {
         const batch = usersToAdd.reduce((ops, user) => {
           user.segment_ids.map(segmentId => {
             const { audience } = audiences[segmentId] || {};
+            this.hull.logger.info("addUsersToAudiences.op", user.email, audience.id);
             return ops.push({
               body: { email_address: user.email, status: "subscribed" },
               method: "post",
@@ -262,6 +263,7 @@ export default class MailchimpList extends SyncAgent {
       .then(responses => {
         this.hull.logger.info("addUsersToAudiences.update", responses.length);
         return Promise.all(_.uniqBy(responses, "email_address").map((mc) => {
+          this.hull.logger.info("addUsersToAudiences.updateUser", mc.email_address);
           const user = _.find(usersToAdd, { email: mc.email_address });
           if (user) {
             // Update user's mailchimp/* traits

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -264,7 +264,7 @@ export default class MailchimpList extends SyncAgent {
         return this.request(batch);
       }, (err) => this.hull.logger.info("error.addUsersToAudiences", err))
       .then(responses => {
-        return _.uniqBy(responses, "email_address").map((mc) => {
+        return Promise.all(_.uniqBy(responses, "email_address").map((mc) => {
           const user = _.find(usersToAdd, { email: mc.email_address });
           if (user) {
             // Update user's mailchimp/* traits
@@ -277,7 +277,7 @@ export default class MailchimpList extends SyncAgent {
           // the testing mailchimp list was changed
           this.hull.logger.warn("addUsersToAudiences.userNotFound", mc);
           return Promise.resolve();
-        });
+        }));
       });
   }
 

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -88,7 +88,7 @@ export default class MailchimpList extends SyncAgent {
   }
 
   // Creates an audience (aka Mailchimp Segment)
-  createAudience(segment, extract = true) {
+  createAudience(segment, extract = false) {
     this.hull.logger.info("createAudience");
     const listId = this.getClient().list_id;
     const rawClient = this.getClient().client;

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -266,7 +266,7 @@ export default class MailchimpList extends SyncAgent {
         return this.request(batch);
       }, (err) => this.hull.logger.info("error.addUsersToAudiences", err))
       .then(responses => {
-        return Promise.map(_.uniqBy(responses, "email_address").map((mc) => {
+        return Promise.all(_.uniqBy(responses, "email_address").map((mc) => {
           const user = _.find(usersToAdd, { email: mc.email_address });
           if (user) {
             // Update user's mailchimp/* traits

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -99,7 +99,7 @@ export default class MailchimpList extends SyncAgent {
         count: 10000,
         type: "static"
       }
-    }, { verbose: false }).then((res) => {
+    }, { verbose: true }).then((res) => {
       const existingSegment = res.segments.filter(s => s.name === segment.name);
       this.hull.utils.log("createAudience.existingSegment", existingSegment);
       if (existingSegment.length > 0) {

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -264,11 +264,11 @@ export default class MailchimpList extends SyncAgent {
         const errors = _.reject(responses, "email_address")
         const uniqSuccess = _.filter(_.uniqBy(responses, "email_address"), "email_address");
         this.hull.logger.info("addUsersToAudiences.update", {
-          responses,
-          uniqSuccess,
-          errors
+          responses: responses.length,
+          uniqSuccess: uniqSuccess.length,
+          errors: errors.length
         });
-        errors.map((e) => this.hull.logger.info.bind(this.hull.logger, "addUsersToAudiences.responseError"));
+        errors.map((e) => this.hull.logger.info("addUsersToAudiences.responseError", e));
         return Promise.all(uniqSuccess.map((mc) => {
           this.hull.logger.info("addUsersToAudiences.updateUser", mc.email_address);
           const user = _.find(usersToAdd, { email: mc.email_address });

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -224,22 +224,13 @@ export default class MailchimpList extends SyncAgent {
     const listId = this.getClient().list_id;
     const rawClient = this.getClient().client;
 
+    this.hull.utils.log("removeAudiences");
     return this.fetchAudiences()
-      .then(segments => {
-        const calls = segments.map(s => {
-          return rawClient.request({
-            method: "delete",
-            path: `/lists/${listId}/segments/${s.id}`
-          });
+      .map(segments => {
+        return rawClient.request({
+          method: "delete",
+          path: `/lists/${listId}/segments/${segment.id}`
         });
-
-        if (calls.length === 0) {
-          return Promise.resolve([]);
-        }
-
-        this.hull.logger.info("Remove Audiences", calls.length);
-
-        return Promise.all(calls);
       });
   }
 
@@ -393,7 +384,7 @@ export default class MailchimpList extends SyncAgent {
   fetchAudiences() {
     return this.request({
       path: "segments",
-      body: { type: "static", count: 100 }
+      query: { type: "static", count: 100 }
     })
     .then(
       ({ segments }) => segments,

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -89,6 +89,7 @@ export default class MailchimpList extends SyncAgent {
 
   // Creates an audience (aka Mailchimp Segment)
   createAudience(segment, extract = true) {
+    this.hull.utils.log("createAudience");
     const listId = this.getClient().list_id;
     const rawClient = this.getClient().client;
     return rawClient.batch({
@@ -100,7 +101,7 @@ export default class MailchimpList extends SyncAgent {
       }
     }, { verbose: false }).then((res) => {
       const existingSegment = res.segments.filter(s => s.name === segment.name);
-
+      this.hull.utils.log("createAudience.existingSegment", existingSegment);
       if (existingSegment.length > 0) {
         return existingSegment.pop();
       }

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -227,6 +227,7 @@ export default class MailchimpList extends SyncAgent {
     this.hull.logger.info("removeAudiences");
     return this.fetchAudiences()
       .map(segment => {
+        this.hull.logger.info("removeAudience", segment.id);
         return rawClient.request({
           method: "delete",
           path: `/lists/${listId}/segments/${segment.id}`

--- a/server/lib/mailchimp-agent.js
+++ b/server/lib/mailchimp-agent.js
@@ -3,6 +3,8 @@ import _ from "lodash";
 import crypto from "crypto";
 import SyncAgent from "./sync-agent";
 
+const batchQueueChecks = [];
+
 const MC_KEYS = [
   "stats.avg_open_rate",
   "stats.avg_click_rate",
@@ -370,7 +372,10 @@ export default class MailchimpList extends SyncAgent {
   getClient() {
     if (!this._client) {
       this._client = new this.MailchimpClientClass(this.getCredentials());
-      setInterval(this.checkBatchQueue.bind(this), process.env.CHECK_BATCH_QUEUE || 30000);
+
+      if (!batchQueueChecks[this._client.api_key]) {
+        batchQueueChecks[this._client.api_key] = setInterval(this.checkBatchQueue.bind(this), process.env.CHECK_BATCH_QUEUE || 30000);
+      }
     }
     return this._client;
   }

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -11,62 +11,43 @@ export default class MailchimpClient {
     this.list_id = mailchimp_list_id;
   }
 
-  // Mailchimp API request
-  // params can be either an operation or an array of operations
-  // Operation : { path, body, method }
-  // If array of operations and length > 1 we automatically use Mailchimp's batch api
+  /**
+   * Replaces `path` param at Mailchimp Api request to fill in the selected
+   * list id
+   * @param  {Object} request
+   * @return {Object}
+   */
+  replacePath(request) {
+    request.path = _.replace(request.path, '{list_id}', this.list_id);
+    return request;
+  }
+
+  /**
+   * Batch operation
+   * @param  {Array} ops
+   * @return {Promise}
+   */
+  batch(ops) {
+    if (_.isEmpty(ops)) {
+      return Promise.resolve([]);
+    }
+    if (_.isArray(ops) && ops.length === 1) {
+      return this.request(ops.pop());
+    }
+
+    ops = ops.map(this.replacePath.bind(this));
+
+    return this.client.batch(ops, { verbose: false });
+  }
+
+  /**
+   * Simple sync operation
+   * @param  {Object} params
+   * @return {Promise} response
+   */
   request(params) {
-    const { client, list_id } = this;
-    return new Promise((resolve, reject) => {
-      const callback = (err, result) => {
-        if (err) {
-          const error = new Error(err.title);
-          error.status = err.status;
-          console.log("Error: ", err);
-          reject(err);
-        } else {
-          resolve(result);
-        }
-      };
-      if (_.isArray(params) && params.length > 1) {
-        const ops = params.map(({ path, body, method }) => {
-          return {
-            body, method,
-            path: `lists/${list_id}/${path}`
-          };
-        });
-        if (ops.length > 0) {
-          client.batch(ops, callback, {
-            interval: 2000,
-            verbose: false,
-          });
-        } else {
-          resolve([]);
-        }
-      } else if (params) {
-        let operation = params;
-        let microbatch = false;
-        if (_.isArray(operation)) {
-          microbatch = true;
-          operation = operation[0];
-        }
-        if (operation) {
-          const { body, query, method, path } = operation;
-          const op = { path: `/lists/${list_id}/${path}`, body, query, method };
-          client.request(op, (err, res) => {
-            if (microbatch) {
-              callback(null, [err || res]);
-            } else {
-              callback(err, res);
-            }
-          });
-        } else {
-          resolve([]);
-        }
-      } else {
-        reject(new Error("Invalid args"));
-      }
-    });
+    params = this.replacePath(params);
+    return this.client.request(params);
   }
 
 }

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -38,7 +38,8 @@ export default class MailchimpClient {
     // microbatch - when the batch consists of only 1 operation,
     // let's do it in a traditional query
     if (ops.length === 1) {
-      return this.request(ops.pop());
+      return this.request(ops.pop())
+        .then(res => [res], err => [err]);
     }
     ops = ops.map(this.replacePath.bind(this));
 

--- a/server/lib/mailchimp-client.js
+++ b/server/lib/mailchimp-client.js
@@ -51,8 +51,8 @@ export default class MailchimpClient {
           operation = operation[0];
         }
         if (operation) {
-          const { body, method, path } = operation;
-          const op = { path: `/lists/${list_id}/${path}`, body, method };
+          const { body, query, method, path } = operation;
+          const op = { path: `/lists/${list_id}/${path}`, body, query, method };
           client.request(op, (err, res) => {
             if (microbatch) {
               callback(null, [err || res]);

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -178,7 +178,7 @@ export default function oauth({
     client.logger.info("Start sync all operation");
     res.end("ok");
     agent.removeAudiences()
-    .then(agent.handleShipUpdate.bind(agent, false))
+    .then(agent.handleShipUpdate.bind(agent, false, true))
     .then(agent.fetchSyncHullSegments.bind(agent))
     .then(segments => {
       client.logger.info("Request the extract for segments", segments.length);

--- a/server/lib/oauth-client.js
+++ b/server/lib/oauth-client.js
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import bodyParser from "body-parser";
-import fetchShip from "./middlewares/fetch-ship";
 import oauth2Factory from "simple-oauth2";
 import rp from "request-promise";
+import Promise from "bluebird";
+
+import fetchShip from "./middlewares/fetch-ship";
 import MailchimpAgent from "./mailchimp-agent";
 import MailchimpClient from "./mailchimp-client";
-import Promise from "bluebird";
 
 export default function oauth({
   name, clientID, clientSecret,

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -47,7 +47,7 @@ export default class SegmentSyncAgent {
    * @param  {Boolean} extract - Start an extract job to batch sync the segment
    * @return {Promise -> audience}
    */
-  createAudience(segment, extract = true) {
+  createAudience(segment, extract = true) { // eslint-disable-line no-unused-vars
     throw new Error("Not Implemented");
   }
 
@@ -57,7 +57,7 @@ export default class SegmentSyncAgent {
    * @param  {String} segmentId - A segment ID
    * @return {Promise -> audience}
    */
-  deleteAudience(audienceId, segmentId) {
+  deleteAudience(audienceId, segmentId) { // eslint-disable-line no-unused-vars
     throw new Error("Not Implemented");
   }
 
@@ -67,7 +67,7 @@ export default class SegmentSyncAgent {
    * @param  {Array<user>} users - A list of users
    * @return {Promise}
    */
-  removeUsersFromAudience(audienceId, users = []) {
+  removeUsersFromAudience(audienceId, users = []) { // eslint-disable-line no-unused-vars
     throw new Error("Not Implemented");
   }
 
@@ -77,7 +77,7 @@ export default class SegmentSyncAgent {
    * @param  {Array<user>} users - A list of users
    * @return {Promise}
    */
-  addUsersToAudience(audienceId, users = []) {
+  addUsersToAudience(audienceId, users = []) { // eslint-disable-line no-unused-vars
     throw new Error("Not Implemented");
   }
 
@@ -244,7 +244,7 @@ export default class SegmentSyncAgent {
     const audienceId = mapping[segment.id] || null;
 
     return audienceId && this.deleteAudience(audienceId, segment.id)
-    .catch(err => console.warn("error deleting audience: ", err));
+    .catch(err => this.hull.logger.error("error deleting audience: ", err));
   }
 
   _getExtractFields() {
@@ -323,11 +323,11 @@ export default class SegmentSyncAgent {
 
     const batch = new BatchStream({ size: 500 });
 
-    return ps.wait(request({ url })
+    return request({ url })
       .pipe(decoder)
       .pipe(batch)
       .pipe(ps.map({ concurrent: 2 }, callback))
-    );
+      .wait();
   }
 
   /**
@@ -394,7 +394,7 @@ export default class SegmentSyncAgent {
         return res;
       }, {});
       return audiencesBySegmentId;
-    }, (err) => console.log(err));
+    }, (err) => this.hull.logger.error(err));
   }
 
 }

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -328,7 +328,7 @@ export default class SegmentSyncAgent {
       .pipe(batch)
       .pipe(ps.map({ concurrent: 2 }, (...args) => {
         try {
-          callback(...args)
+          callback(...args);
         } catch (e) {
           console.error(e);
           throw e;

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -326,7 +326,14 @@ export default class SegmentSyncAgent {
     return request({ url })
       .pipe(decoder)
       .pipe(batch)
-      .pipe(ps.map({ concurrent: 2 }, callback))
+      .pipe(ps.map({ concurrent: 2 }, (...args) => {
+        try {
+          callback(...args)
+        } catch (e) {
+          console.error(e);
+          throw e;
+        }
+      }))
       .wait();
   }
 

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -157,11 +157,11 @@ export default class SegmentSyncAgent {
    * defined in the ship's settings exist
    * @return {Promise}
    */
-  handleShipUpdate(extract = true) {
+  handleShipUpdate(extract = true, create = false) {
     this.hull.logger.info("handleShipUpdate");
     return this.getAudiencesBySegmentId().then((segments = {}) => {
       return Promise.all(_.map(segments, item => {
-        return item.audience || this.createAudience(item.segment, extract);
+        return item.audience || (create && this.createAudience(item.segment, extract));
       }));
     });
   }

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -360,6 +360,7 @@ export default class SegmentSyncAgent {
    */
   fetchSyncHullSegments() {
     const segmentIds = this.getPrivateSetting("synchronized_segments") || [];
+    hull.utils.log("fetchSyncHullSegments.segmentIds", segmentIds);
     if (_.isEmpty(segmentIds)) {
       return Promise.resolve([]);
     }

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -212,7 +212,10 @@ export default class SegmentSyncAgent {
    */
   handleUserLeftSegment(user, segment) {
     return this.getOrCreateAudienceForSegment(segment).then(audience => {
-      return audience && this.removeUsersFromAudience(audience.id, [user]);
+      if (this.shouldSyncUser(user)) {
+        return audience && this.removeUsersFromAudience(audience.id, [user]);
+      }
+      return this.removeUsersFromAudiences([user]);
     });
   }
 

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -360,7 +360,7 @@ export default class SegmentSyncAgent {
    */
   fetchSyncHullSegments() {
     const segmentIds = this.getPrivateSetting("synchronized_segments") || [];
-    hull.utils.log("fetchSyncHullSegments.segmentIds", segmentIds);
+    this.hull.utils.log("fetchSyncHullSegments.segmentIds", segmentIds);
     if (_.isEmpty(segmentIds)) {
       return Promise.resolve([]);
     }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,6 @@
 require("babel-register")({ presets: ["es2015", "stage-0"] });
 
+require("./mailchimp-client-tests");
 require("./mailchimp-agent-tests");
 require("./create-audience-tests");
 require("./ship-update");

--- a/tests/mailchimp-client-tests.js
+++ b/tests/mailchimp-client-tests.js
@@ -1,0 +1,42 @@
+/* global describe, it */
+import assert from "assert";
+import Promise from "bluebird";
+import sinon from "sinon";
+import proxyquire from "proxyquire";
+
+describe("MailchimpClient", () => {
+  describe("batch", () => {
+    it(`should return an array in microbatch in successfull query`, () => {
+      class MailchimpStub {
+        request(params) {
+          return new Promise.resolve({ res: "test" });
+        }
+      }
+      const MailchimpClient = proxyquire("../server/lib/mailchimp-client", { 'mailchimp-api-v3': MailchimpStub }).default;
+
+      const mailchimpClient = new MailchimpClient({});
+
+      return mailchimpClient.batch([{ path: "test", method: "get" }])
+        .then(res => {
+          assert.deepEqual(res, [{ res: "test" }]);
+        });
+    });
+
+    it(`should return an array in microbatch in rejected query`, () => {
+
+      class MailchimpStub {
+        request(params) {
+          return new Promise.reject({ err: "test" });
+        }
+      }
+      const MailchimpClient = proxyquire("../server/lib/mailchimp-client", { 'mailchimp-api-v3': MailchimpStub }).default;
+
+      const mailchimpClient = new MailchimpClient({});
+
+      return mailchimpClient.batch([{ path: "test", method: "get" }])
+        .then(res => {
+          assert.deepEqual(res, [{ err: "test" }]);
+        });
+    });
+  });
+});


### PR DESCRIPTION
1. Rebuilt MailchimpClient methods and usage
2. Added Mailchimp API calls limiter/throttling
3. Added BatchQueue check
4. Fixed user update Promises
5. Added more logging and introduced debug level (for mailchimp request details)
6. Enhanced error handling in stream processing
7. ESlint ignore in sync-agent
8. Adjust unit tests
9. Fix the loop of `notify ship:update` -> `handleShipUpdate` -> `createAudience` -> `saveAudienceMapping` -> `this.hull.put(this.ship.id, { private_settings })` -> `notify ship:update` - the audiences are created only on sync all operation and on segment update event. Not on ship update event.

